### PR TITLE
rename interface to base

### DIFF
--- a/prts/base/time_series_metrics.py
+++ b/prts/base/time_series_metrics.py
@@ -3,8 +3,8 @@ from typing import Any
 import numpy as np
 
 
-class InterfaceTimeSeriesMetrics:
-    """ This class is interface for time series metrics """
+class BaseTimeSeriesMetrics:
+    """Base class for time series metrics """
 
     def score(self, real: np.ndarray, pred: np.ndarray) -> Any:
         """

--- a/prts/time_series_metrics/precision.py
+++ b/prts/time_series_metrics/precision.py
@@ -2,10 +2,10 @@ from typing import Any
 
 import numpy as np
 
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 
 
-class TimeSeriesPrecision(InterfaceTimeSeriesMetrics):
+class TimeSeriesPrecision(BaseTimeSeriesMetrics):
     """ This class calculates precision for time series """
 
     def __init__(self, beta=1.0, alpha=0.0, cardinality="one", bias="flat"):

--- a/prts/time_series_metrics/precision_recall.py
+++ b/prts/time_series_metrics/precision_recall.py
@@ -2,10 +2,10 @@ from typing import Any
 
 import numpy as np
 
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 
 
-class TimeSeriesPrecisionRecall(InterfaceTimeSeriesMetrics):
+class TimeSeriesPrecisionRecall(BaseTimeSeriesMetrics):
     """ This class calculates precision and recall for time series """
 
     def score(self, real: np.ndarray, pred: np.ndarray) -> Any:

--- a/prts/time_series_metrics/recall.py
+++ b/prts/time_series_metrics/recall.py
@@ -2,10 +2,10 @@ from typing import Any
 
 import numpy as np
 
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 
 
-class TimeSeriesRecall(InterfaceTimeSeriesMetrics):
+class TimeSeriesRecall(BaseTimeSeriesMetrics):
     """ This class calculates recall for time series """
 
     def __init__(self, beta=1.0, alpha=0.0, cardinality="one", bias="flat"):

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,19 +1,19 @@
 import unittest
 
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 
 
 class TestPrecision(unittest.TestCase):
-    def test_InterfaceTimeSeriesMetricsClass_udf_gamma(self):
+    def test_BaseTimeSeriesMetricsClass_udf_gamma(self):
         """ Check the value of udf_gamma.
         """
-        obj = InterfaceTimeSeriesMetrics()
+        obj = BaseTimeSeriesMetrics()
         self.assertEqual(obj._udf_gamma(), 1.0)
 
-    def test_InterfaceTimeSeriesMetricsClass_gamma_select(self):
+    def test_BaseTimeSeriesMetricsClass_gamma_select(self):
         """ Check the value of gamma_select.
         """
-        obj = InterfaceTimeSeriesMetrics()
+        obj = BaseTimeSeriesMetrics()
         self.assertEqual(obj._gamma_select("one", 1), 1.0)
         self.assertEqual(obj._gamma_select("reciprocal", 2), 0.5)
         self.assertEqual(obj._gamma_select("udf_gamma", 2), 1.0)

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,16 +1,16 @@
 import unittest
 
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 from prts.time_series_metrics.precision import TimeSeriesPrecision
 
 
 class TestPrecision(unittest.TestCase):
-    def test_PrecisionClass_inherited_InterfaceTimeSeriesMetrics(self):
-        """ Check if it inherits InterfaceTimeSeriesMetircs.
+    def test_PrecisionClass_inherited_BaseTimeSeriesMetrics(self):
+        """ Check if it inherits BaseTimeSeriesMetircs.
         """
         obj = TimeSeriesPrecision()
         self.assertTrue(
-            isinstance(obj, InterfaceTimeSeriesMetrics)
+            isinstance(obj, BaseTimeSeriesMetrics)
         )
 
     def test_PrecisionClass_init(self):

--- a/tests/test_precision_recall.py
+++ b/tests/test_precision_recall.py
@@ -1,16 +1,16 @@
 import unittest
 
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 from prts.time_series_metrics.precision_recall import TimeSeriesPrecisionRecall
 
 
 class TestPrecision(unittest.TestCase):
-    def test_PrecisionRecallClass_inherited_InterfaceTimeSeriesMetrics(self):
-        """ InterfaceTimeSeriesMetircsを継承しているかチェック
+    def test_PrecisionRecallClass_inherited_BaseTimeSeriesMetrics(self):
+        """ BaseTimeSeriesMetircsを継承しているかチェック
         """
         obj = TimeSeriesPrecisionRecall()
         self.assertTrue(
-            isinstance(obj, InterfaceTimeSeriesMetrics)
+            isinstance(obj, BaseTimeSeriesMetrics)
         )
 
 

--- a/tests/test_recall.py
+++ b/tests/test_recall.py
@@ -1,15 +1,15 @@
-from prts.interfaces.time_series_metrics import InterfaceTimeSeriesMetrics
+from prts.base.time_series_metrics import BaseTimeSeriesMetrics
 from prts.time_series_metrics.recall import TimeSeriesRecall
 
 import unittest
 
 class TestRecall(unittest.TestCase):
-    def test_recall_inherited_InterfaceTimeSeriesMetrics(self):
-        """ InterfaceTimeSeriesMetircsを継承しているかチェック
+    def test_recall_inherited_BaseTimeSeriesMetrics(self):
+        """ BaseTimeSeriesMetircsを継承しているかチェック
         """
         recall = TimeSeriesRecall()
         self.assertTrue(
-            isinstance(recall, InterfaceTimeSeriesMetrics)
+            isinstance(recall, BaseTimeSeriesMetrics)
         )
 
 


### PR DESCRIPTION
## Summary
To clarify the role of class, we should rename the class as follows:

```
InterfaceTimeSeriesMetrics -> BaseTimeSeriesMetrics
```

This issue will be assigned after all implementations of the interface class are finished.

## Goal

Refactor all corresponding codes. 

## Todo
- [x] rename class name
- [x] rewrite the code which is using the interface class
- [x] check if all unit tests are passed

## Deadline
yyyy / mm / dd  

## Parent issue
If the parent issue exists, post a link here.  

## References
If there are any reference links, they are described here.  

## Notes
Other comments.
