### PR TITLE
Add __version__ attribute to package

### DIFF
--- a/prts/__init__.py
+++ b/prts/__init__.py
@@ -3,6 +3,9 @@ from prts.time_series_metrics.precision import TimeSeriesPrecision
 from prts.time_series_metrics.recall import TimeSeriesRecall
 
 
+__version__ = "1.0.0.3"
+
+
 def ts_precision(real, pred, alpha=0.0, cardinality="one", bias="flat"):
     """Compute the time series precision.
 


### PR DESCRIPTION
## Summary

prts has no `prts.__version__` property, which makes integrating it in other packages complicated. Many tools use `<module>.__version__` to check compatibility at runtime.

This PR adds the `__version__` property to the package, set to the [current version on PyPI](https://pypi.org/project/prts/).
